### PR TITLE
Extend max_allowed_packet to 128M

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,3 @@
+FROM percona:5.7
+
+RUN echo 'max_allowed_packet = 128M' >> /etc/mysql/percona-server.conf.d/mysqld.cnf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 
 db:
-    image: percona
+    build: db
     restart: always
     volumes:
         - ./mysql:/var/lib/mysql
     env_file: conf/mysql
 dbclient:
-    image: percona
+    build: db
     command: bash
     links:
         - db


### PR DESCRIPTION
This fixed the "MySQL has gone away" problem while importing sql.